### PR TITLE
Deduplicate scripts APIs as done in phoenix/854258d

### DIFF
--- a/PxCs/Interface/PxVm.cs
+++ b/PxCs/Interface/PxVm.cs
@@ -58,6 +58,11 @@ namespace PxCs.Interface
 
         public delegate void PxVmExternalDefaultCallback(IntPtr vmPtr, string missingCallbackName);
         public delegate void PxVmExternalCallback(IntPtr vmPtr);
+        
+        [DllImport(DLLNAME)] public static extern IntPtr pxScriptGetSymbolById(IntPtr vm, uint index);
+        [DllImport(DLLNAME)] public static extern IntPtr pxScriptGetSymbolByName(IntPtr vm, string name);
+        [DllImport(DLLNAME)] public static extern uint pxScriptSymbolGetId(IntPtr symbol);
+        [DllImport(DLLNAME)] public static extern IntPtr pxScriptSymbolGetName(IntPtr symbol);
 
         [DllImport(DLLNAME)] public static extern IntPtr pxVmLoad(IntPtr buffer);
         [DllImport(DLLNAME)] public static extern IntPtr pxVmLoadFromVfs(IntPtr vfs, string name);
@@ -96,10 +101,6 @@ namespace PxCs.Interface
         [return: MarshalAs(UnmanagedType.U1)]
         [DllImport(DLLNAME)] public static extern bool pxVmCallFunctionByIndex(IntPtr vm, uint index, IntPtr zero /*==IntPtr.Zero*/);
 
-        [DllImport(DLLNAME)] public static extern IntPtr pxVmGetSymbolByIndex(IntPtr vm, uint index);
-        [DllImport(DLLNAME)] public static extern IntPtr pxVmGetSymbolByName(IntPtr vm, string name);
-        [DllImport(DLLNAME)] public static extern uint pxVmSymbolGetId(IntPtr symbol);
-        [DllImport(DLLNAME)] public static extern IntPtr pxVmSymbolGetName(IntPtr symbol);
         [DllImport(DLLNAME)] public static extern IntPtr pxVmInstanceAllocateByIndex(IntPtr vm, uint index, PxVmInstanceType type);
         [DllImport(DLLNAME)] public static extern IntPtr pxVmInstanceAllocateByName(IntPtr vm, string name, PxVmInstanceType type);
         [DllImport(DLLNAME)] public static extern IntPtr pxVmInstanceInitializeByIndex(IntPtr vm, uint index, PxVmInstanceType type, IntPtr existing);
@@ -297,14 +298,14 @@ namespace PxCs.Interface
 
         public static PxVmSymbolData? GetSymbol(IntPtr vm, uint index)
         {
-            var symbolPtr = pxVmGetSymbolByIndex(vm, index);
+            var symbolPtr = pxScriptGetSymbolById(vm, index);
 
             return GetSymbolData(symbolPtr);
         }
 
         public static PxVmSymbolData? GetSymbol(IntPtr vm, string name)
         {
-            var symbolPtr = pxVmGetSymbolByName(vm, name);
+            var symbolPtr = pxScriptGetSymbolByName(vm, name);
 
             return GetSymbolData(symbolPtr);
         }
@@ -316,8 +317,8 @@ namespace PxCs.Interface
 
             return new PxVmSymbolData()
             {
-                id = pxVmSymbolGetId(symbolPtr),
-                name = pxVmSymbolGetName(symbolPtr).MarshalAsString()
+                id = pxScriptSymbolGetId(symbolPtr),
+                name = pxScriptSymbolGetName(symbolPtr).MarshalAsString()
             };
         }
 


### PR DESCRIPTION
In C++-land `phoenix::vm` inherits from `phoenix::script`, thus using the `pxScript*`-APIs with a `PxVm` pointer is fine.

See phoenix update in https://github.com/GothicKit/phoenix-shared-interface/commit/854258dc11a9d6caa82980d8efe1ab995961622f

I can't run the tests to check that it actually works, sadly :/

```
17:37:37 luis@sys.main phoenix-csharp-interface refactor/deduplicate-script-api ? dotnet test --environment GOTHIC1_ASSET_DIR="/mnt/games/Gothic/Gothic108kDE/"                  
  Determining projects to restore...
  All projects are up-to-date for restore.
  PxCs -> /mnt/projects/GothicKit/phoenix-csharp-interface/PxCs/bin/Debug/netstandard2.1/PxCs.dll
  PxCs.Tests -> /mnt/projects/GothicKit/phoenix-csharp-interface/PxCs.Tests/bin/Debug/net6/PxCs.Tests.dll
Test run for /mnt/projects/GothicKit/phoenix-csharp-interface/PxCs.Tests/bin/Debug/net6/PxCs.Tests.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.6.3 (x64)
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.
Testhost process for source(s) '/mnt/projects/GothicKit/phoenix-csharp-interface/PxCs.Tests/bin/Debug/net6/PxCs.Tests.dll' exited with error: You must install or update .NET to run this application.
App: /mnt/projects/GothicKit/phoenix-csharp-interface/PxCs.Tests/bin/Debug/net6/testhost.dll
Architecture: x64
Framework: 'Microsoft.NETCore.App', version '6.0.0' (x64)
.NET location: /usr/share/dotnet/
The following frameworks were found:
  7.0.9 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]
Learn about framework resolution:
https://aka.ms/dotnet/app-launch-failed
To install missing framework, download:
https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=6.0.0&arch=x64&rid=arch-x64
. Please check the diagnostic logs for more information.

Test Run Aborted.
```