### PR TITLE
bugfix/font

### DIFF
--- a/PxCs/Interface/PxFont.cs
+++ b/PxCs/Interface/PxFont.cs
@@ -23,7 +23,7 @@ namespace PxCs.Interface
 
         public static PxFontData? LoadFont(IntPtr vfsPtr, string fontname, params Format[] supportedTextureFormats)
         {
-            var fontPtr = pxFntLoadFromVfs(vfsPtr, "FONT_DEFAULT.FNT");
+            var fontPtr = pxFntLoadFromVfs(vfsPtr, fontname);
 
             if (fontPtr == IntPtr.Zero)
                 return null;


### PR DESCRIPTION
fixse LoadFont to use the fontname parameter instead of a custom string